### PR TITLE
Use ALE pattern matching to disable linters/fixes for certain file types

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -99,6 +99,11 @@ let g:airline#extensions#ale#enabled = 1
 let g:ale_fixers = {
 \   'python': ['black', 'isort'],
 \}
+let g:ale_pattern_options = {
+\   '\.min\.css$': {'ale_linters': [], 'ale_fixers': []},
+\   '\.bundle\.js$': {'ale_linters': [], 'ale_fixers': []},
+\   '\.min\.js$': {'ale_linters': [], 'ale_fixers': []},
+\}
 
 "vim-terraform
 let g:terraform_fold_sections = 1


### PR DESCRIPTION
Don't lint minified JS/CSS, or JS bundles created by webpack.