### PR TITLE
Remove plugins.txt now that vim-plug is installed

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -1,9 +1,0 @@
-https://github.com/scrooloose/nerdtree.git,nerdtree
-https://github.com/tpope/vim-fugitive.git,fugitive
-https://github.com/tpope/vim-commentary.git,commentary
-https://github.com/editorconfig/editorconfig-vim.git,editorconfig
-https://github.com/garbas/vim-snipmate.git,snipmate
-https://github.com/honza/vim-snippets.git,snippets
-https://github.com/MarcWeber/vim-addon-mw-utils.git,addon-mw-utils
-https://github.com/tomtom/tlib_vim.git,tlib
-https://github.com/kchmck/vim-coffee-script.git,vim-coffee-script


### PR DESCRIPTION
The file was unused because the scripts that needed it have all been deleted. All contents are represented in the vim-plug section of vimrc.